### PR TITLE
fix: Correct rendering issue on login page

### DIFF
--- a/AdmIn.UI/Components/Pages/Login.razor
+++ b/AdmIn.UI/Components/Pages/Login.razor
@@ -21,7 +21,7 @@
 {
     <RadzenRow Gap="0" Class="rz-mx-auto login-container-row-mobile">
         <RadzenColumn Size="12">
-            <RadzenCard Class="rz-shadow-0 rz-border-radius-0 login-form-card"> {/* Removed rz-p-6 */}
+            <RadzenCard Class="rz-shadow-0 rz-border-radius-0 login-form-card">
                 <img src="img/AdmIn.png" alt="AdmIn Logo" class="login-logo" />
                 <RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" Class="rz-mb-6 login-title">
                     Ingrese sus credenciales
@@ -38,8 +38,8 @@
 else
 {
     <RadzenRow Gap="0" Class="rz-my-12 rz-mx-auto login-container-row-desktop" JustifyContent="JustifyContent.Center">
-        <RadzenColumn Size="12" SizeMD="6"> {/* Centered column */}
-            <RadzenCard Class="rz-shadow-0 rz-border-radius-0 login-form-card"> {/* Removed rz-p-12 */}
+        <RadzenColumn Size="12" SizeMD="6">
+            <RadzenCard Class="rz-shadow-0 rz-border-radius-0 login-form-card">
                 <img src="img/AdmIn.png" alt="AdmIn Logo" class="login-logo" />
                 <RadzenText TextStyle="TextStyle.H5" TagName="TagName.H2" Class="rz-mb-6 login-title">
                     Ingrese sus credenciales


### PR DESCRIPTION
This commit resolves a bug where erroneous text (internal development comments) was being rendered directly on the login page, and the intended background and styles were not appearing correctly.

The fix involves:
- Removing invalid comment syntax (`{/* ... */}`) from `AdmIn.UI/Components/Pages/Login.razor`. These comments were breaking the Blazor component parsing and rendering.

With this correction, the login page should now render as intended with the conceptual design, including the layered background, styled form card, and proper responsive behavior.